### PR TITLE
Fix Clang warnings

### DIFF
--- a/coverage.c
+++ b/coverage.c
@@ -37,7 +37,7 @@ const unsigned char gray_icc[] =
 void test_gray(qcms_profile *output_profile)
 {
 	unsigned char srct[3] = { 221, 79, 129};
-	unsigned char outt[3];
+	unsigned char outt[4];
 	qcms_transform *transform;
 	qcms_profile *gray_profile = qcms_profile_from_memory(gray_icc, sizeof(gray_icc));
 	assert(gray_profile);

--- a/malloc-fail.c
+++ b/malloc-fail.c
@@ -74,9 +74,6 @@ void test_gray_precache(qcms_profile *output_profile)
 
 }
 void do_test(void) {
-	unsigned char srct[4] = { 221, 79, 129, 92};
-	unsigned char outt[4];
-	qcms_transform *transform;
 	qcms_profile *input_profile, *output_profile, *rgb;
 	qcms_CIE_xyY invalid_white_point = { 0., 0., 1.};
 	qcms_CIE_xyY white_point = { 0.9, 1., 1.};


### PR DESCRIPTION
Second try, this time based against the v4 branch which appears to be the focus of development. To verify, edit `Makefile` as follows:

Add line `CC=clang`. Add `-lm` to `LDFLAGS`. Run `make -B`.

This came up trying to build Chromium on Windows with Clang (but actually it turns out all the Chromium issues are fixed now, so this is not required for Chromium).

Cheers

Matt (mgiuca@chromium.org)
